### PR TITLE
Modify loading of modules

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -2,8 +2,6 @@ import argparse
 import collections
 import glob
 import math
-import os
-print(os.system("pip list -v"))
 import numpy as np
 import psutil
 import resource

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -2,8 +2,9 @@ import argparse
 import collections
 import glob
 import math
-import numpy as np
 import os
+print(os.system("pip list -v"))
+import numpy as np
 import psutil
 import resource
 import time

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -2,6 +2,7 @@ import argparse
 import collections
 import glob
 import math
+import os
 import numpy as np
 import psutil
 import resource

--- a/mlproject/README.md
+++ b/mlproject/README.md
@@ -1,4 +1,4 @@
-## Running Application 4 with Mantik CLI
+## Running Application 1 with Mantik CLI
 To run this application in juwels-booster with the mantik CLI follow these instructions:
 
 1. Login to juwels-booster via SSH. To access juwels-booster via SSH, please follow the instructions provided in this [tutorial](https://apps.fz-juelich.de/jsc/hps/juwels/access.html#ssh-login)

--- a/mlproject/README.md
+++ b/mlproject/README.md
@@ -26,12 +26,14 @@ Set up a project in Mantik to enable the execution of your experiment. For a ste
 
 ### In your local mlproject
 
-1. Set `Python` in `unicore-config-venv.yaml` to the path of your virtual enviroment
+1. Set `PreRunCommand` in `unicore-config-venv.yaml` to the path of your virtual enviroment
 
-```
-Environment:
-  Python: /path/to/<venv-name>
-```
+<pre><code> PreRunCommand:
+    Command: >
+      module load Stages/2022 GCCcore/.11.2.0 NCCL/2.11.4-CUDA-11.5 Python/3.9.6;
+      source <b>/path/to/&lt;venv-name&gt;</b>/bin/activate;
+</code></pre>
+
 
 2. Run your experiment with mantik
 ```

--- a/mlproject/README.md
+++ b/mlproject/README.md
@@ -1,5 +1,9 @@
-### In juwelsbooster
-1. Set python to version 3.9. For this load the following modules:
+## Running Application 4 with Mantik CLI
+To run this application in juwels-booster with the mantik CLI follow these instructions:
+
+1. Login to juwels-booster via SSH. To access juwels-booster via SSH, please follow the instructions provided in this [tutorial](https://apps.fz-juelich.de/jsc/hps/juwels/access.html#ssh-login)
+
+2. Once you are logged in on juwels-booster, set python to version 3.9. For this load the following modules:
 ```
 ml --force purge
 ml use $OTHERSTAGES
@@ -8,25 +12,20 @@ ml GCCcore/.11.2.0
 ml Python/3.9.6
 ```
 
-2. Create a virtual enviroment and activate it:
+3. Create a virtual environment and activate it:
 ```
 python -m venv <venv-name>
 source <venv-name>/bin/activate
 ```
 
-3. Install ap1 dependencies with pip. The requirements file is in the `env_setup` file
+4. Install ap1 dependencies with pip. The requirements file is in the `env_setup` file
 ```
 pip install -r maelstrom-train/benchmark/requirements_wo_modules.txt
 ```
 
-### In mantik
+5. The results will be logged to an Experiment on the MLflow tracking server on Mantik. Set up a project in Mantik and create a new Experiment. Note its experiment Id, which will be needed in the submission command. For a step-by-step guide, refer to the Quickstart tutorial available [here](https://mantik-ai.gitlab.io/mantik/ui/quickstart.html).
 
-Set up a project in Mantik to enable the execution of your experiment. For a step-by-step guide, refer to the quickstart tutorial available [here](https://mantik-ai.gitlab.io/mantik/ui/quickstart.html)
-
-
-### In your local mlproject
-
-1. Set `PreRunCommand` in `unicore-config-venv.yaml` to the path of your virtual enviroment
+6. Update the `unicore-config-venv.yaml` file by specifying the `PreRunCommand` with the path to your virtual environment.
 
 <pre><code> PreRunCommand:
     Command: >
@@ -35,7 +34,7 @@ Set up a project in Mantik to enable the execution of your experiment. For a ste
 </code></pre>
 
 
-2. Run your experiment with mantik
+7. Run your experiment with mantik
 ```
 mantik runs submit <absolute path to maelstrom-train/mlproject directory> --backend-config unicore-config-venv.yaml --entry-point main --experiment-id <experiment ID> -v
 ```

--- a/mlproject/unicore-config-venv.yaml
+++ b/mlproject/unicore-config-venv.yaml
@@ -1,11 +1,10 @@
 UnicoreApiUrl: https://zam2125.zam.kfa-juelich.de:9112/JUWELS/rest/core
 Environment:
-  Python: /p/project/deepacf/maelstrom/grau1/ap1
-  Modules:
-    - Stages/2022
-    - GCCcore/.11.2.0
-    - NCCL/2.11.4-CUDA-11.5
-    - Python/3.9.6
+  PreRunCommand:
+    Command: >
+      module load Stages/2022 GCCcore/.11.2.0 NCCL/2.11.4-CUDA-11.5 Python/3.9.6;
+      source /p/project/deepacf/maelstrom/grau1/ap1/bin/activate;
+    ExecuteOnLoginNode: False
   Variables:
     GIT_PYTHON_REFRESH: quiet
 Resources:


### PR DESCRIPTION
Findings
- Apparently the modules don't vanish when loading them before the activation of the virtual environment
- Also the modules Stages/2022 and Python/3.9.6 should never be loaded after venv activation. If this is done, the local Python will be used instead of the one in the venv causing the system to search within the local Python's site-packages directory instead of the venv's Python's site-packages directory.

For these reasons the backend-config was changed